### PR TITLE
Clarify spec, correct test vector in BIP-85

### DIFF
--- a/bip-0085.mediawiki
+++ b/bip-0085.mediawiki
@@ -96,8 +96,8 @@ OUTPUT
 ==Reference Implementation==
 
 * Python library implementation: [https://github.com/ethankosakovsky/bip85]
+* Python 3.x library implementation: [https://github.com/akarve/bipsea]
 * JavaScript library implementation: [https://github.com/hoganri/bip85-js]
-* Python 3.x implementation: [https://github.com/akarve/bipsea]
 
 ==Applications==
 

--- a/bip-0085.mediawiki
+++ b/bip-0085.mediawiki
@@ -75,10 +75,12 @@ OUTPUT
 
 BIP85-DRNG-SHAKE256 is a deterministic random number generator for cryptographic functions that require deterministic outputs, but where the input to that function requires more than the 64 bytes provided by BIP85's HMAC output. BIP85-DRNG-SHAKE256 uses BIP85 to seed a SHAKE256 stream (from the SHA-3 standard). The input must be exactly 64 bytes long (from the BIP85 HMAC output).
 
+The derivation path format is: <code>m/83696968'/0'/{index}'</code>
+
 RSA key generation is an example of a function that requires orders of magnitude more than 64 bytes of random input. Further, it is not possible to precalculate the amount of random input required until the function has completed.
 
     drng_reader = BIP85DRNG.new(bip85_entropy)
-    rsa_key = RSA.generate_key(4096, drng_reader.read())
+    rsa_key = RSA.generate_key(4096, drng_reader.read)
 
 ===Test Vectors===
 INPUT:
@@ -95,6 +97,7 @@ OUTPUT
 
 * Python library implementation: [https://github.com/ethankosakovsky/bip85]
 * JavaScript library implementation: [https://github.com/hoganri/bip85-js]
+* Python 3.x implementation: [https://github.com/akarve/bipsea]
 
 ==Applications==
 
@@ -207,7 +210,7 @@ OUTPUT:
 ===HD-Seed WIF===
 Application number: 2'
 
-Uses 256 bits[1] of entropy as the secret exponent to derive a private key and encode as a compressed WIF which will be used as the hdseed for Bitcoin Core wallets.
+Uses the most significant 256 bits[1] of entropy as the secret exponent to derive a private key and encode as a compressed WIF which will be used as the hdseed for Bitcoin Core wallets.
 
 Path format is <code>m/83696968'/2'/{index}'</code>
 
@@ -223,8 +226,14 @@ OUTPUT
 Application number: 32'
 
 Taking 64 bytes of the HMAC digest, the first 32 bytes are the chain code, and second 32 bytes[1] are the private key for BIP32 XPRV value. Child number, depth, and parent fingerprint are forced to zero.
+(Note that this ordering is opposite BIP32, where the chain code is the second 32 bytes.)
+
 
 Path format is <code>m/83696968'/32'/{index}'</code>
+
+
+Applications may support Testnet by emitting TPRV keys if and only if the input
+root key is a testnet key.
 
 INPUT:
 * MASTER BIP32 ROOT KEY: xprv9s21ZrQH143K2LBWUUQRFXhucrQqBpKdRRxNVq2zBqsx8HVqFk2uYo8kmbaLLHRdqtQpUm98uKfu3vca1LqdGhUtyoFnCNkfmXRyPXLjbKb
@@ -285,7 +294,7 @@ INPUT:
 * PATH: m/83696968'/707764'/21'/0'
 
 OUTPUT
-* DERIVED ENTROPY=d7ad61d4a76575c5bad773feeb40299490b224e8e5df6c8ad8fe3d0a6eed7b85ead9fef7bcca8160f0ee48dc6e92b311fc71f2146623cc6952c03ce82c7b63fe
+* DERIVED ENTROPY=74a2e87a9ba0cdd549bdd2f9ea880d554c6c355b08ed25088cfa88f3f1c4f74632b652fd4a8f5fda43074c6f6964a3753b08bb5210c8f5e75c07a4c2a20bf6e9
 * DERIVED PWD=dKLoepugzdVJvdL56ogNV
 
 ===PWD BASE85===
@@ -295,7 +304,7 @@ The derivation path format is: <code>m/83696968'/707785'/{pwd_len}'/{index}'</co
 
 `10 <= pwd_len <= 80`
 
-Base85 encode the all 64 bytes of entropy.
+Base85 encode all 64 bytes of entropy.
 Remove any spaces or new lines inserted by Base64 encoding process. Slice base85 result string
 on index 0 to `pwd_len`. This slice is the password. `pwd_len` is limited to 80 characters.
 


### PR DESCRIPTION
Summary of changes:
* Clarify index for BIP85-DRNG
* Clarify drng_reader.read is a first-class function (not an evaluation)
* Clarify possibility for TPRV keys
* Add new reference implementation in Python
* Clarify that HD-Seed-WIF uses msbs
* Correct DERIVED ENTROPY for PWD BASE64 test vector.
  See the following relevant test cases:
    * xfail - https://github.com/akarve/bipsea/blob/4305fe8aa1d0684d2a112947da446d759a778d15/tests/test_bip85.py#L54
    * corrected - https://github.com/akarve/bipsea/blob/4305fe8aa1d0684d2a112947da446d759a778d15/tests/test_bip85.py#L41
 
Unit tests and complete implementation that led to these suggestions is in [akarve/bipsea](https://github.com/akarve/bipsea/blob/main/tests/test_bip85.py).